### PR TITLE
change the error from http stack with response body

### DIFF
--- a/client.go
+++ b/client.go
@@ -295,7 +295,8 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 
 	resp, err := c.cfg.HTTPClient.Do(request)
 	if err != nil {
-		return resp, err
+		dump, _ := httputil.DumpResponse(resp, true)
+		return resp, errors.New(fmt.Sprintf("%s with Response body: %s", err.Error(), string(dump)))
 	}
 
 	if c.cfg.Debug {

--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -254,7 +254,8 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 
 	resp, err := c.cfg.HTTPClient.Do(request)
 	if err != nil {
-		return resp, err
+        dump, _ := httputil.DumpResponse(resp, true)
+        return resp, errors.New(fmt.Sprintf("%s with Response body: %s", err.Error(), string(dump)))
 	}
 
 	if c.cfg.Debug {


### PR DESCRIPTION
This PR change the openapi client template to change the error to include the response body if available