### PR TITLE
Check if response is nil to avoid panic during dump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,4 @@ module github.com/authlete/openapi-for-go
 
 go 1.13
 
-require (
-)
+require github.com/stretchr/testify v1.8.2

--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -254,7 +254,10 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 
 	resp, err := c.cfg.HTTPClient.Do(request)
 	if err != nil {
-        dump, _ := httputil.DumpResponse(resp, true)
+		if resp == nil {
+			return resp, err
+		}
+		dump, _ := httputil.DumpResponse(resp, true)
         return resp, errors.New(fmt.Sprintf("%s with Response body: %s", err.Error(), string(dump)))
 	}
 


### PR DESCRIPTION
Issue: `Panic` when no response is returned from the server.
This behavior can be reproduced when there is no response from the server. 
Just try applying to terraform files without starting the Authlete server.